### PR TITLE
Preserved the input when running irfft.

### DIFF
--- a/fft.lua
+++ b/fft.lua
@@ -111,7 +111,7 @@ function signal.irfft(input, size)
    local output = torch.Tensor(size):typeAs(input):zero();
    local output_data = torch.data(output);
 
-   local flags = fftw.ESTIMATE
+   local flags = fftw.ESTIMATE + fftw.PRESERVE_INPUT
    local plan  = fftw.plan_dft_c2r_1d(size, input_data_cast, output_data, flags)
    fftw.execute(plan)
    fftw.destroy_plan(plan)   
@@ -203,7 +203,7 @@ function signal.irfft2(input, size)
    if input:dim() ~= 3 or input:size(3) ~= 2 then
       error('Input has to be 3D Tensor of size NxMx2 (Complex input with NxM points)')
    end
-   input = input:contiguous() -- make sure input is contiguous
+   input = input:clone():contiguous() -- make sure input is contiguous and preserved
    local input_data = torch.data(input)
    local input_data_cast = ffi.cast(fftw_complex_cast, input_data)
    local size = size or (input:size(2) - 1) * 2

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -91,9 +91,15 @@ function signaltest.irfft()
    local output1 = signal.fft(input)
    local outputi1 = signal.ifft(output1)
    local output2 = signal.rfft(input)
+   local output2_copy = output2:clone()
    local outputi2 = signal.irfft(output2)
    for i=1,outputi1:size(1) do
       asserteq(outputi1[i][1], outputi2[i], 'error in irfft')
+   end
+   for i=1,output2:size(1) do
+      for j=1,output2:size(2) do
+         asserteq(output2[i][j], output2_copy[i][j], 'error in preserving of irfft input')
+      end
    end
 end
 
@@ -102,10 +108,18 @@ function signaltest.irfft2()
    local output1 = signal.fft2(input)
    local outputi1 = signal.ifft2(output1)
    local output2 = signal.rfft2(input)
+   local output2_copy = output2:clone()
    local outputi2 = signal.irfft2(output2)
    for i=1,outputi1:size(1) do
       for j=1,outputi1:size(2) do
 	 asserteq(outputi1[i][j][1], outputi2[i][j], 'error in irfft2')
+      end
+   end
+   for i=1,output2:size(1) do
+      for j=1,output2:size(2) do
+         for k=1,output2:size(3) do
+             asserteq(output2[i][j][k], output2_copy[i][j][k], 'error in preserving of irfft2 input')
+         end
       end
    end
 end


### PR DESCRIPTION
By default, fftw is [not preserving](http://www.fftw.org/doc/Planner-Flags.html) the input when running a c2r operation:

> FFTW_PRESERVE_INPUT specifies that an out-of-place transform must not change its input array. This is ordinarily the default, except **for c2r and hc2r** (i.e. complex-to-real) transforms for which **FFTW_DESTROY_INPUT is the default**. In the latter cases, passing FFTW_PRESERVE_INPUT will attempt to use algorithms that do not destroy the input, at the expense of worse performance; for multi-dimensional c2r transforms, however, no input-preserving algorithms are implemented and the planner will return NULL if one is requested.

I used the PRESERVE_INPUT flag for the 1D irfft.
And I used a copy of the input for the 2D irfft2.

I guess it is intended to preserve the input.
