### PR TITLE
Fix for signal.stft corrupting the input

### DIFF
--- a/fft.lua
+++ b/fft.lua
@@ -409,7 +409,7 @@ function signal.stft(input, window_size, window_stride, window_type)
    local window_index = 1
    for i=1,length,window_stride do
       if (i+window_size-1) > length then break; end
-      local window = input[{{i,i+window_size-1}}]
+      local window = input[{{i,i+window_size-1}}]:clone()
       -- apply preprocessing
       apply_window(window, window_type)
       -- fft


### PR DESCRIPTION
signal.stft was applying the windows to the original signal instead of copies, so each window was corrupting the original signal (which made all frames except the first to have incorrect values). Now it clones the frame before applying the window.