### PR TITLE
Add support for plan_many_fft and 1D FFTs

### DIFF
--- a/tests/fftM.lua
+++ b/tests/fftM.lua
@@ -2,8 +2,8 @@ require 'xlua'
 local signal = require 'signal'
 
 function test_fftM(A)
-    Af = signal.fftM(A)
-    Aif = signal.ifftM(A)
+    local Af = signal.fftM(A)
+    local Aif = signal.ifftM(A)
     for i=1,A:size(1) do
         assert((Af[i] - signal.fft(A[i])):norm() == 0)
         assert((Aif[i] - signal.ifft(A[i])):norm() == 0)

--- a/tests/fftM.lua
+++ b/tests/fftM.lua
@@ -1,0 +1,40 @@
+require 'xlua'
+local signal = require 'signal'
+
+function test_fftM(A)
+    Af = signal.fftM(A)
+    Aif = signal.ifftM(A)
+    for i=1,A:size(1) do
+        assert((Af[i] - signal.fft(A[i])):norm() == 0)
+        assert((Aif[i] - signal.ifft(A[i])):norm() == 0)
+    end
+end
+
+-- test real tensors
+test_fftM(torch.randn(100,100))
+print("Real tensors OK")
+
+-- test complex tensors
+test_fftM(torch.randn(100,100,2))
+print("Complex tensors OK")
+
+-- evaluate runtime improvements
+local A = torch.randn(100,100)
+local p = xlua.Profiler()
+local iters = 1000
+
+p:start('single fftM')
+for i=1,iters do
+    signal.fftM(A)
+end
+p:lap('single fftM', iters)
+
+p:start('multiple fft')
+for i=1,iters do
+    for i=1,A:size(1) do
+        signal.fft(A[i])
+    end
+end
+p:lap('multiple fft', iters)
+
+p:printAll()


### PR DESCRIPTION
This patch add support for fftw's `plan_many_dft` to torch-signal. Using `plan_many_dft` gives a significant speed up when multiple (i)FFTs are applied to a batch of data. The current patch supports only 1D FFTs, but could easily be extended for higher ranks.

A simple test case and profiling of the code is included.

For 1D FFTs the speed up on my machine is over 10x for a batch size of 100 and vectors of dim 100:

```
$ profiler report:
$ real 0.000205 | cpu 0.000205 <single fftM>
$ real 0.002479 | cpu 0.002479 <multiple fft>
```